### PR TITLE
Release 1.14.0

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cryptomator
 	pkgdesc = Multiplatform transparent client-side encryption of your files in the cloud.
-	pkgver = 1.13.0
-	pkgrel = 2
+	pkgver = 1.14.0_beta2
+	pkgrel = 1
 	url = https://cryptomator.org/
 	arch = any
 	license = GPL3
@@ -18,10 +18,10 @@ pkgbase = cryptomator
 	noextract = jdk.tar.gz
 	noextract = openjfx.zip
 	options = !strip
-	source = cryptomator-1.13.0.tar.gz::https://github.com/cryptomator/cryptomator/archive/refs/tags/1.13.0.tar.gz
-	source = cryptomator-1.13.0.tar.gz.asc::https://github.com/cryptomator/cryptomator/releases/download/1.13.0/cryptomator-1.13.0.tar.gz.asc
+	source = cryptomator-1.14.0-beta2.tar.gz::https://github.com/cryptomator/cryptomator/archive/refs/tags/1.14.0-beta2.tar.gz
+	source = cryptomator-1.14.0-beta2.tar.gz.asc::https://github.com/cryptomator/cryptomator/releases/download/1.14.0-beta2/cryptomator-1.14.0-beta2.tar.gz.asc
 	validpgpkeys = 58117AFA1F85B3EEC154677D615D449FE6E6A235
-	sha256sums = d7d0389c3b8632d5fec08a38973c305ee48bcdd2208861f74f0fe570bf11ce30
+	sha256sums = c87a384acdb1f36adb92415e2d060110a8c0994dbcf8f664f511dc23ac086d12
 	sha256sums = SKIP
 
 pkgname = cryptomator

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = cryptomator
 	pkgdesc = Multiplatform transparent client-side encryption of your files in the cloud.
-	pkgver = 1.14.0_beta2
+	pkgver = 1.14.0
 	pkgrel = 1
 	url = https://cryptomator.org/
 	arch = any
@@ -18,10 +18,10 @@ pkgbase = cryptomator
 	noextract = jdk.tar.gz
 	noextract = openjfx.zip
 	options = !strip
-	source = cryptomator-1.14.0-beta2.tar.gz::https://github.com/cryptomator/cryptomator/archive/refs/tags/1.14.0-beta2.tar.gz
-	source = cryptomator-1.14.0-beta2.tar.gz.asc::https://github.com/cryptomator/cryptomator/releases/download/1.14.0-beta2/cryptomator-1.14.0-beta2.tar.gz.asc
+	source = cryptomator-1.14.0.tar.gz::https://github.com/cryptomator/cryptomator/archive/refs/tags/1.14.0.tar.gz
+	source = cryptomator-1.14.0.tar.gz.asc::https://github.com/cryptomator/cryptomator/releases/download/1.14.0/cryptomator-1.14.0.tar.gz.asc
 	validpgpkeys = 58117AFA1F85B3EEC154677D615D449FE6E6A235
-	sha256sums = c87a384acdb1f36adb92415e2d060110a8c0994dbcf8f664f511dc23ac086d12
+	sha256sums = fef22a6237fd8379d0eada1bcbdbe86cc4c6e7873289ee9dc0a762fe1d6774aa
 	sha256sums = SKIP
 
 pkgname = cryptomator

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -17,9 +17,9 @@ _jdkver=22.0.2+9
 _jfxver=22.0.2
 source=("cryptomator-${pkgver//_/-}.tar.gz::https://github.com/cryptomator/cryptomator/archive/refs/tags/${pkgver//_/-}.tar.gz"
         "cryptomator-${pkgver//_/-}.tar.gz.asc::https://github.com/cryptomator/cryptomator/releases/download/${pkgver//_/-}/cryptomator-${pkgver//_/-}.tar.gz.asc")
-source_x86_64=("jdk.tar.gz::https://github.com/adoptium/temurin22-binaries/releases/download/jdk-${_jdkver//\+//%2B}/OpenJDK22U-jdk_x64_linux_hotspot_${_jdkver//\+/_}.tar.gz"
+source_x86_64=("jdk.tar.gz::https://github.com/adoptium/temurin22-binaries/releases/download/jdk-${_jdkver//\+/%2B}/OpenJDK22U-jdk_x64_linux_hotspot_${_jdkver//\+/_}.tar.gz"
                "openjfx.zip::https://download2.gluonhq.com/openjfx/${_jfxver}/openjfx-${_jfxver}_linux-x64_bin-jmods.zip")
-source_aarch64=("jdk.tar.gz::https://github.com/adoptium/temurin22-binaries/releases/download/jdk-${_jdkver//\+//%2B}/OpenJDK22U-jdk_aarch64_linux_hotspot_${_jdkver//\+/_}.tar.gz"
+source_aarch64=("jdk.tar.gz::https://github.com/adoptium/temurin22-binaries/releases/download/jdk-${_jdkver//\+/%2B}/OpenJDK22U-jdk_aarch64_linux_hotspot_${_jdkver//\+/_}.tar.gz"
                 "openjfx.zip::https://download2.gluonhq.com/openjfx/${_jfxver}/openjfx-${_jfxver}_linux-aarch64_bin-jmods.zip")
 noextract=('jdk.tar.gz' 'openjfx.zip')
 sha256sums=('c87a384acdb1f36adb92415e2d060110a8c0994dbcf8f664f511dc23ac086d12'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Sebastian Stenzel <sebastian.stenzel@gmail.com>
 
 pkgname=cryptomator
-pkgver=1.14.0_beta2
+pkgver=1.14.0
 pkgrel=1
 pkgdesc="Multiplatform transparent client-side encryption of your files in the cloud."
 arch=('any')
@@ -22,7 +22,7 @@ source_x86_64=("jdk.tar.gz::https://github.com/adoptium/temurin22-binaries/relea
 source_aarch64=("jdk.tar.gz::https://github.com/adoptium/temurin22-binaries/releases/download/jdk-${_jdkver//\+/%2B}/OpenJDK22U-jdk_aarch64_linux_hotspot_${_jdkver//\+/_}.tar.gz"
                 "openjfx.zip::https://download2.gluonhq.com/openjfx/${_jfxver}/openjfx-${_jfxver}_linux-aarch64_bin-jmods.zip")
 noextract=('jdk.tar.gz' 'openjfx.zip')
-sha256sums=('c87a384acdb1f36adb92415e2d060110a8c0994dbcf8f664f511dc23ac086d12'
+sha256sums=('fef22a6237fd8379d0eada1bcbdbe86cc4c6e7873289ee9dc0a762fe1d6774aa'
             'SKIP')
 sha256sums_x86_64=('05cd9359dacb1a1730f7c54f57e0fed47942a5292eb56a3a0ee6b13b87457a43'
                    'd44bff3b94d5668fdee18a938d7b1269026d663d44765f02d29a9bdfd3fa1eb0')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,8 +4,8 @@
 # Contributor: Sebastian Stenzel <sebastian.stenzel@gmail.com>
 
 pkgname=cryptomator
-pkgver=1.13.0
-pkgrel=2
+pkgver=1.14.0_beta2
+pkgrel=1
 pkgdesc="Multiplatform transparent client-side encryption of your files in the cloud."
 arch=('any')
 url="https://cryptomator.org/"
@@ -13,19 +13,21 @@ license=('GPL3')
 depends=('fuse3' 'alsa-lib' 'hicolor-icon-theme' 'libxtst' 'libnet' 'libxrender')
 makedepends=('maven' 'unzip')
 optdepends=('keepassxc-cryptomator: Use KeePassXC to store vault passwords' 'ttf-hanazono: Install this font when using Japanese system language')
+_jdkver=22.0.2+9
+_jfxver=22.0.2
 source=("cryptomator-${pkgver//_/-}.tar.gz::https://github.com/cryptomator/cryptomator/archive/refs/tags/${pkgver//_/-}.tar.gz"
         "cryptomator-${pkgver//_/-}.tar.gz.asc::https://github.com/cryptomator/cryptomator/releases/download/${pkgver//_/-}/cryptomator-${pkgver//_/-}.tar.gz.asc")
-source_x86_64=("jdk.tar.gz::https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jdk_x64_linux_hotspot_22.0.1_8.tar.gz"
-               "openjfx.zip::https://download2.gluonhq.com/openjfx/22.0.1/openjfx-22.0.1_linux-x64_bin-jmods.zip")
-source_aarch64=("jdk.tar.gz::https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jdk_aarch64_linux_hotspot_22.0.1_8.tar.gz"
-                "openjfx.zip::https://download2.gluonhq.com/openjfx/22.0.1/openjfx-22.0.1_linux-aarch64_bin-jmods.zip")
+source_x86_64=("jdk.tar.gz::https://github.com/adoptium/temurin22-binaries/releases/download/jdk-${_jdkver//\+//%2B}/OpenJDK22U-jdk_x64_linux_hotspot_${_jdkver//\+/_}.tar.gz"
+               "openjfx.zip::https://download2.gluonhq.com/openjfx/${_jfxver}/openjfx-${_jfxver}_linux-x64_bin-jmods.zip")
+source_aarch64=("jdk.tar.gz::https://github.com/adoptium/temurin22-binaries/releases/download/jdk-${_jdkver//\+//%2B}/OpenJDK22U-jdk_aarch64_linux_hotspot_${_jdkver//\+/_}.tar.gz"
+                "openjfx.zip::https://download2.gluonhq.com/openjfx/${_jfxver}/openjfx-${_jfxver}_linux-aarch64_bin-jmods.zip")
 noextract=('jdk.tar.gz' 'openjfx.zip')
-sha256sums=('d7d0389c3b8632d5fec08a38973c305ee48bcdd2208861f74f0fe570bf11ce30'
+sha256sums=('c87a384acdb1f36adb92415e2d060110a8c0994dbcf8f664f511dc23ac086d12'
             'SKIP')
-sha256sums_x86_64=('e59c6bf801cc023a1ea78eceb5e6756277f1564cd0a421ea984efe6cb96cfcf8'
-                   'fbb22f35951c2e049cc2554dd03c2c56b4f5adc4b2ae9248872f46175ac103d8')
-sha256sums_aarch64=('d8488fa1e4e8c1e318cef4c0fc3842a7f15a4cf52b27054663bb94471f54b3fa'
-                    '1982ad168a5e8d7cf4a9458a7d088b4f0552d0ac3f24f23fb88f8bc7e8d69a13')
+sha256sums_x86_64=('05cd9359dacb1a1730f7c54f57e0fed47942a5292eb56a3a0ee6b13b87457a43'
+                   'd44bff3b94d5668fdee18a938d7b1269026d663d44765f02d29a9bdfd3fa1eb0')
+sha256sums_aarch64=('dac62747b5158c4bf4c4636432e3bdb9dea47f80f0c9d1d007f19bd5483b7d29'
+                    '3d5457136690c4f5bb9522d38b45218e045bdac13c24aa4c808c7c8d17d039c7')
 options=('!strip')
 
 validpgpkeys=('58117AFA1F85B3EEC154677D615D449FE6E6A235')
@@ -51,7 +53,7 @@ build() {
   "$JAVA_HOME/bin/jlink" \
     --output runtime \
     --module-path "$JMODS_PATH" \
-    --add-modules java.base,java.desktop,java.instrument,java.logging,java.naming,java.net.http,java.scripting,java.sql,java.xml,javafx.base,javafx.graphics,javafx.controls,javafx.fxml,jdk.unsupported,jdk.security.auth,jdk.accessibility,jdk.management.jfr,jdk.net \
+    --add-modules java.base,java.desktop,java.instrument,java.logging,java.naming,java.net.http,java.scripting,java.sql,java.xml,javafx.base,javafx.graphics,javafx.controls,javafx.fxml,jdk.unsupported,jdk.security.auth,jdk.accessibility,jdk.management.jfr,jdk.net,java.compiler \
     --strip-native-commands \
     --no-header-files \
     --no-man-pages \
@@ -85,6 +87,7 @@ build() {
     --java-options "-Dcryptomator.disableUpdateCheck=true" \
     --java-options "-Dcryptomator.buildNumber=\"aur-${pkgrel}\"" \
     --java-options "-Dcryptomator.appVersion=\"${pkgver//_/-}\"" \
+    --java-options "-Dcryptomator.integrationsLinux.autoStartCmd=\"cryptomator\"" \
     --app-version "${pkgver//_*/}" \
     --verbose
 }


### PR DESCRIPTION
This PR updates the Cryptomator package to version 1.14.0

Changes so far:
* add java.compiler to included modules
* add autostart command
* update jfx to 22.0.2
* update jdk to 22.0.2+9